### PR TITLE
remove unused import, make ant buildable by specifying classpath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ build/
 *.jar
 *.war
 *.ear
-/bin
 
 # idea
 *.iml

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/build.xml
+++ b/build.xml
@@ -1,9 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project default="create_run_jar" name="Create Runnable Jar for Project slner with Jar-in-Jar Loader">
-    <!--this file was created by Eclipse Runnable JAR Export Wizard-->
-    <!--ANT 1.7 is required                                        -->
-    <target name="create_run_jar">
-        <jar destfile="slner-all.jar" basedir="build/classes">
+
+    <property name="lib.dir"     value="lib"/>
+
+    <path id="classpath">
+        <fileset dir="${lib.dir}" includes="*.jar"/>
+    </path>
+
+    <target name="compile">
+        <mkdir dir="build/classes"/>
+        <javac srcdir="src" destdir="build/classes" classpathref="classpath"/>
+    </target>
+
+    <target name="create_run_jar" depends="compile">
+        <jar destfile="build/libs/slner-1.1.jar" basedir="build/classes">
             <manifest>
                 <attribute name="Main-Class" value="si.ijs.slner.SloveneNER"/>
                 <attribute name="Class-Path" value="./ mallet-deps.jar mallet.jar"/>

--- a/build.xml
+++ b/build.xml
@@ -3,7 +3,7 @@
     <!--this file was created by Eclipse Runnable JAR Export Wizard-->
     <!--ANT 1.7 is required                                        -->
     <target name="create_run_jar">
-        <jar destfile="slner-all.jar">
+        <jar destfile="slner-all.jar" basedir="build/classes">
             <manifest>
                 <attribute name="Main-Class" value="si.ijs.slner.SloveneNER"/>
                 <attribute name="Class-Path" value="./ mallet-deps.jar mallet.jar"/>

--- a/sbin/run.sh
+++ b/sbin/run.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 set -ex
 
+parent_path=$( cd "$(dirname "${BASH_SOURCE}")" ; pwd -P )
+
+
 SLNER_VERSION=1.1
-SLNER_JAR="build/libs/slner-$SLNER_VERSION.jar"
+SLNER_JAR="${parent_path}/build/libs/slner-$SLNER_VERSION.jar"
 
 java -cp "$SLNER_JAR:lib/*" \
   si.ijs.slner.SloveneNER $@

--- a/sbin/train.sh
+++ b/sbin/train.sh
@@ -1,2 +1,8 @@
 #!/bin/sh
-java -jar slner-all.jar --in corpus/ssj500kv1_1.zip --out-model model.ser.gz
+
+parent_path=$( cd "$(dirname "${BASH_SOURCE}")" ; pwd -P )
+
+SLNER_VERSION=1.1
+SLNER_JAR="${parent_path}/build/libs/slner-$SLNER_VERSION.jar"
+
+java -jar $SLNER_JAR --in corpus/ssj500kv1_1.zip --out-model model.ser.gz

--- a/src/si/ijs/slner/SentenceIterator.java
+++ b/src/si/ijs/slner/SentenceIterator.java
@@ -2,7 +2,6 @@ package si.ijs.slner;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.function.Consumer;
 
 import si.ijs.slner.tei.Doc;
 import si.ijs.slner.tei.Token;


### PR DESCRIPTION
Pretty minor stuff for anyone who still uses ant build tool instead of gradle